### PR TITLE
arch: Define STRIP_LOG for abseil

### DIFF
--- a/protobuf.lua
+++ b/protobuf.lua
@@ -6,6 +6,10 @@ configuration { "*" }
 
 uuid "1A92AB33-0DCB-4953-BCB9-467862B5FE1F"
 
+defines {
+  "STRIP_LOG=1", -- Prevent abseil-cpp making restricted windows calls for stack tracing
+}
+
 includedirs {
   "src",
   _3RDPARTY_DIR .. "/abseil-cpp",


### PR DESCRIPTION
For issue: https://devtopia.esri.com/runtime/vital-spark/issues/215

This PR sets the STRIP_LOG preprocessor symbol to ensure that it includes abseil headers with logging off. This suppresses the inclusion of stack-trace related code that depends on Windows API calls that are not available to UWP and thus trigger app certification failures.

Relates to https://github.com/Esri/abseil-cpp/pull/3

[vTest (3rdparty all targets/platforms)](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1317/downstreambuildview/)