### PR TITLE
Rshepherd/font1884 update protobuf 35.1 third_party headers

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -18,6 +18,7 @@ class ProtobufConan(ConanFile):
         # headers
         self.copy("*.h*", src=base + "src", dst=relative + "src")
         self.copy("*.inc", src=base + "src", dst=relative + "src")
+        self.copy("*.h*", src=base + "third_party", dst=relative + "third_party")
 
         # libraries
         output = "output/" + str(self.settings.platform_architecture_target) + "/staticlib"

--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -18,7 +18,7 @@ class ProtobufConan(ConanFile):
         # headers
         self.copy("*.h*", src=base + "src", dst=relative + "src")
         self.copy("*.inc", src=base + "src", dst=relative + "src")
-        self.copy("*.h*", src=base + "third_party", dst=relative + "third_party")
+        self.copy("*.h*", src=base + "third_party/utf8_range", dst=relative + "third_party/utf8_range")
 
         # libraries
         output = "output/" + str(self.settings.platform_architecture_target) + "/staticlib"


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/fontana/issues/1884

Pull protobuf/third_party headers in.
Currently these are just two files.
```
c:\runtime\3rdparty\protobuf\third_party>dir *.h /s
 Volume in drive C is OS
 Volume Serial Number is C424-90C5

 Directory of c:\runtime\3rdparty\protobuf\third_party\utf8_range

01/07/2026  12:48               562 utf8_range.h
01/07/2026  12:48               866 utf8_validity.h
               2 File(s)          1,428 bytes

     Total Files Listed:
               2 File(s)          1,428 bytes
```

