### PR TITLE
add symbol checker that is required for new IPS proto files

### DIFF
--- a/protobuf.lua
+++ b/protobuf.lua
@@ -60,6 +60,7 @@ files {
   "src/google/protobuf/repeated_field.cc",
   "src/google/protobuf/repeated_ptr_field.cc",
   "src/google/protobuf/stubs/common.cc",
+  "src/google/protobuf/symbol_checker.cc",
   "src/google/protobuf/text_format.cc",
   "src/google/protobuf/unknown_field_set.cc",
   "src/google/protobuf/wire_format.cc",


### PR DESCRIPTION
### Description
We are adding a [new protobuf definition](https://devtopia.esri.com/3rdparty/protobuf_generated/pull/30) to the generated repository that requires additional source files. This PR adds all necessary files to successfully use the new PB definition.


### Tests
3rd-party build (all targets): https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/2157/downstreambuildview/
MapsSDK build: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/53544/downstreambuildview/